### PR TITLE
improve random seed to a slightly more random number

### DIFF
--- a/src/openbsd.h
+++ b/src/openbsd.h
@@ -5,11 +5,13 @@
 #include <cstddef>
 #include <cstring>
 #include <ctime>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 inline
 void arc4random_buf(void *buf, size_t nbytes)
 {
-
     for( size_t n = 0; n < nbytes; ++ n)
         ((char*)(buf))[n] = rand() %256;
 }
@@ -17,7 +19,10 @@ void arc4random_buf(void *buf, size_t nbytes)
 inline
 void arc4random_init(void)
 {
-    srand( (unsigned int) time(NULL));
+  struct timeval tv;
+  gettimeofday(&tv, 0);
+  // this is not very good, but we lack a portable non-blocking API
+  srand( ((unsigned int) tv.tv_usec) ^ (unsigned int)getpid());
 }
 
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -9,7 +9,9 @@ int main()
     std::string password = "top_secret";
 
     std::string hash = bcrypt::generateHash(password);
+    std::cout << "Hash: " << hash << std::endl;
 
+    hash=bcrypt::generateHash(password);
     std::cout << "Hash: " << hash << std::endl;
 
     std::cout << "\"" << password << "\" : " << bcrypt::validatePassword(password,hash) << std::endl;


### PR DESCRIPTION
When provisioning new users, I found all user password hashes ended up with the same salt. Turns out this code uses time(0) as a non-blocking random seed. Doing non-blocking good random from 2003 C++ is not easy, so I upgraded the code to use the microsecond component of gettimeofday xored with the pid as the random seed. I also enhanced the test code to hash the same password twice, which shows you the salt is different. 